### PR TITLE
Tracing interface

### DIFF
--- a/business/apps_test.go
+++ b/business/apps_test.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"context"
 	"testing"
 
 	osapps_v1 "github.com/openshift/api/apps/v1"
@@ -21,7 +22,7 @@ import (
 func setupAppService(k8s *kubetest.K8SClientMock) AppService {
 	prom := new(prometheustest.PromClientMock)
 	layer := NewWithBackends(k8s, prom, nil)
-	return AppService{k8s: k8s, prom: prom, businessLayer: layer}
+	return &appService{k8s: k8s, prom: prom, businessLayer: layer}
 }
 
 func TestGetAppListFromDeployments(t *testing.T) {
@@ -47,7 +48,7 @@ func TestGetAppListFromDeployments(t *testing.T) {
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]core_v1.Service{}, nil)
 	svc := setupAppService(k8s)
 
-	appList, _ := svc.GetAppList("Namespace", false)
+	appList, _ := svc.GetAppList(context.TODO(), "Namespace", false)
 
 	assert.Equal("Namespace", appList.Namespace.Name)
 
@@ -78,7 +79,7 @@ func TestGetAppFromDeployments(t *testing.T) {
 	config.Set(conf)
 	svc := setupAppService(k8s)
 
-	appDetails, _ := svc.GetApp("Namespace", "httpbin")
+	appDetails, _ := svc.GetApp(context.TODO(), "Namespace", "httpbin")
 
 	assert.Equal("Namespace", appDetails.Namespace.Name)
 	assert.Equal("httpbin", appDetails.Name)
@@ -112,7 +113,7 @@ func TestGetAppListFromReplicaSets(t *testing.T) {
 	k8s.On("GetServices", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]string")).Return([]core_v1.Service{}, nil)
 	svc := setupAppService(k8s)
 
-	appList, _ := svc.GetAppList("Namespace", false)
+	appList, _ := svc.GetAppList(context.TODO(), "Namespace", false)
 
 	assert.Equal("Namespace", appList.Namespace.Name)
 
@@ -144,7 +145,7 @@ func TestGetAppFromReplicaSets(t *testing.T) {
 
 	svc := setupAppService(k8s)
 
-	appDetails, _ := svc.GetApp("Namespace", "httpbin")
+	appDetails, _ := svc.GetApp(context.TODO(), "Namespace", "httpbin")
 
 	assert.Equal("Namespace", appDetails.Namespace.Name)
 	assert.Equal("httpbin", appDetails.Name)

--- a/business/health.go
+++ b/business/health.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -12,11 +15,21 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus"
 )
 
 // HealthService deals with fetching health from various sources and convert to kiali model
-type HealthService struct {
+type HealthService interface {
+	GetServiceHealth(ctx context.Context, namespace, service, rateInterval string, queryTime time.Time) (models.ServiceHealth, error)
+	GetAppHealth(ctx context.Context, namespace, app, rateInterval string, queryTime time.Time) (models.AppHealth, error)
+	GetWorkloadHealth(ctx context.Context, namespace, workload, workloadType, rateInterval string, queryTime time.Time) (models.WorkloadHealth, error)
+	GetNamespaceServiceHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error)
+	GetNamespaceWorkloadHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error)
+	GetNamespaceAppHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error)
+}
+
+type healthService struct {
 	prom          prometheus.ClientInterface
 	k8s           kubernetes.ClientInterface
 	businessLayer *Layer
@@ -26,20 +39,20 @@ type HealthService struct {
 var HealthAnnotation = []models.AnnotationKey{models.RateHealthAnnotation}
 
 // GetServiceHealth returns a service health (service request error rate)
-func (in *HealthService) GetServiceHealth(namespace, service, rateInterval string, queryTime time.Time) (models.ServiceHealth, error) {
-	rqHealth, err := in.getServiceRequestsHealth(namespace, service, rateInterval, queryTime)
+func (in *healthService) GetServiceHealth(ctx context.Context, namespace, service, rateInterval string, queryTime time.Time) (models.ServiceHealth, error) {
+	rqHealth, err := in.getServiceRequestsHealth(ctx, namespace, service, rateInterval, queryTime)
 	return models.ServiceHealth{Requests: rqHealth}, err
 }
 
 // GetAppHealth returns an app health from just Namespace and app name (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetAppHealth(namespace, app, rateInterval string, queryTime time.Time) (models.AppHealth, error) {
+func (in *healthService) GetAppHealth(ctx context.Context, namespace, app, rateInterval string, queryTime time.Time) (models.AppHealth, error) {
 	appLabel := config.Get().IstioLabels.AppLabelName
 
 	selectorLabels := make(map[string]string)
 	selectorLabels[appLabel] = app
 	labelSelector := labels.FormatLabels(selectorLabels)
 
-	ws, err := fetchWorkloads(in.businessLayer, namespace, labelSelector)
+	ws, err := fetchWorkloads(ctx, in.businessLayer, namespace, labelSelector)
 	if err != nil {
 		log.Errorf("Error fetching Workloads per namespace %s and app %s: %s", namespace, app, err)
 		return models.AppHealth{}, err
@@ -48,7 +61,7 @@ func (in *HealthService) GetAppHealth(namespace, app, rateInterval string, query
 	return in.getAppHealth(namespace, app, rateInterval, queryTime, ws)
 }
 
-func (in *HealthService) getAppHealth(namespace, app, rateInterval string, queryTime time.Time, ws models.Workloads) (models.AppHealth, error) {
+func (in *healthService) getAppHealth(namespace, app, rateInterval string, queryTime time.Time, ws models.Workloads) (models.AppHealth, error) {
 	health := models.EmptyAppHealth()
 
 	// Perf: do not bother fetching request rate if there are no workloads or no workload has sidecar
@@ -75,8 +88,8 @@ func (in *HealthService) getAppHealth(namespace, app, rateInterval string, query
 }
 
 // GetWorkloadHealth returns a workload health from just Namespace and workload (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetWorkloadHealth(namespace, workload, workloadType, rateInterval string, queryTime time.Time) (models.WorkloadHealth, error) {
-	w, err := fetchWorkload(in.businessLayer, namespace, workload, workloadType)
+func (in *healthService) GetWorkloadHealth(ctx context.Context, namespace, workload, workloadType, rateInterval string, queryTime time.Time) (models.WorkloadHealth, error) {
+	w, err := fetchWorkload(ctx, in.businessLayer, namespace, workload, workloadType)
 	if err != nil {
 		return models.WorkloadHealth{}, err
 	}
@@ -92,7 +105,7 @@ func (in *HealthService) GetWorkloadHealth(namespace, workload, workloadType, ra
 	}
 
 	// Add Telemetry info
-	rate, err := in.getWorkloadRequestsHealth(namespace, workload, rateInterval, queryTime)
+	rate, err := in.getWorkloadRequestsHealth(ctx, namespace, workload, rateInterval, queryTime)
 	return models.WorkloadHealth{
 		WorkloadStatus: status,
 		Requests:       rate,
@@ -100,8 +113,8 @@ func (in *HealthService) GetWorkloadHealth(namespace, workload, workloadType, ra
 }
 
 // GetNamespaceAppHealth returns a health for all apps in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceAppHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
-	appEntities, err := fetchNamespaceApps(in.businessLayer, namespace, "")
+func (in *healthService) GetNamespaceAppHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
+	appEntities, err := fetchNamespaceApps(ctx, in.businessLayer, namespace, "")
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +122,7 @@ func (in *HealthService) GetNamespaceAppHealth(namespace, rateInterval string, q
 	return in.getNamespaceAppHealth(namespace, appEntities, rateInterval, queryTime)
 }
 
-func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities namespaceApps, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
+func (in *healthService) getNamespaceAppHealth(namespace string, appEntities namespaceApps, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
 	allHealth := make(models.NamespaceAppHealth)
 
 	// Perf: do not bother fetching request rate if no workloads or no workload has sidecar
@@ -146,12 +159,12 @@ func (in *HealthService) getNamespaceAppHealth(namespace string, appEntities nam
 }
 
 // GetNamespaceServiceHealth returns a health for all services in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceServiceHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error) {
+func (in *healthService) GetNamespaceServiceHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error) {
 	var services *models.ServiceList
 	var err error
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespace(context.TODO(), namespace); err != nil {
+	if _, err := in.businessLayer.Namespace.GetNamespace(ctx, namespace); err != nil {
 		return nil, err
 	}
 
@@ -160,14 +173,14 @@ func (in *HealthService) GetNamespaceServiceHealth(namespace, rateInterval strin
 		IncludeOnlyDefinitions: true,
 		IncludeIstioResources:  false,
 	}
-	services, err = in.businessLayer.Svc.GetServiceList(criteria)
+	services, err = in.businessLayer.Svc.GetServiceList(ctx, criteria)
 	if err != nil {
 		return nil, err
 	}
 	return in.getNamespaceServiceHealth(namespace, services, rateInterval, queryTime), nil
 }
 
-func (in *HealthService) getNamespaceServiceHealth(namespace string, services *models.ServiceList, rateInterval string, queryTime time.Time) models.NamespaceServiceHealth {
+func (in *healthService) getNamespaceServiceHealth(namespace string, services *models.ServiceList, rateInterval string, queryTime time.Time) models.NamespaceServiceHealth {
 	allHealth := make(models.NamespaceServiceHealth)
 
 	// Prepare all data (note that it's important to provide data for all services, even those which may not have any health, for overview cards)
@@ -196,8 +209,8 @@ func (in *HealthService) getNamespaceServiceHealth(namespace string, services *m
 }
 
 // GetNamespaceWorkloadHealth returns a health for all workloads in given Namespace (thus, it fetches data from K8S and Prometheus)
-func (in *HealthService) GetNamespaceWorkloadHealth(namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
-	wl, err := fetchWorkloads(in.businessLayer, namespace, "")
+func (in *healthService) GetNamespaceWorkloadHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
+	wl, err := fetchWorkloads(ctx, in.businessLayer, namespace, "")
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +218,7 @@ func (in *HealthService) GetNamespaceWorkloadHealth(namespace, rateInterval stri
 	return in.getNamespaceWorkloadHealth(namespace, wl, rateInterval, queryTime)
 }
 
-func (in *HealthService) getNamespaceWorkloadHealth(namespace string, ws models.Workloads, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
+func (in *healthService) getNamespaceWorkloadHealth(namespace string, ws models.Workloads, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
 	// Perf: do not bother fetching request rate if no workloads or no workload has sidecar
 	hasSidecar := false
 
@@ -271,9 +284,9 @@ func fillWorkloadRequestRates(allHealth models.NamespaceWorkloadHealth, rates mo
 	}
 }
 
-func (in *HealthService) getServiceRequestsHealth(namespace, service, rateInterval string, queryTime time.Time) (models.RequestHealth, error) {
+func (in *healthService) getServiceRequestsHealth(ctx context.Context, namespace, service, rateInterval string, queryTime time.Time) (models.RequestHealth, error) {
 	rqHealth := models.NewEmptyRequestHealth()
-	svc, err := in.businessLayer.Svc.GetService(namespace, service)
+	svc, err := in.businessLayer.Svc.GetService(ctx, namespace, service)
 	if err != nil {
 		return rqHealth, err
 	}
@@ -294,7 +307,7 @@ func (in *HealthService) getServiceRequestsHealth(namespace, service, rateInterv
 	return rqHealth, nil
 }
 
-func (in *HealthService) getAppRequestsHealth(namespace, app, rateInterval string, queryTime time.Time) (models.RequestHealth, error) {
+func (in *healthService) getAppRequestsHealth(namespace, app, rateInterval string, queryTime time.Time) (models.RequestHealth, error) {
 	rqHealth := models.NewEmptyRequestHealth()
 
 	inbound, outbound, err := in.prom.GetAppRequestRates(namespace, app, rateInterval, queryTime)
@@ -311,7 +324,7 @@ func (in *HealthService) getAppRequestsHealth(namespace, app, rateInterval strin
 	return rqHealth, nil
 }
 
-func (in *HealthService) getWorkloadRequestsHealth(namespace, workload, rateInterval string, queryTime time.Time) (models.RequestHealth, error) {
+func (in *healthService) getWorkloadRequestsHealth(ctx context.Context, namespace, workload, rateInterval string, queryTime time.Time) (models.RequestHealth, error) {
 	rqHealth := models.NewEmptyRequestHealth()
 	inbound, outbound, err := in.prom.GetWorkloadRequestRates(namespace, workload, rateInterval, queryTime)
 	if err != nil {
@@ -323,7 +336,7 @@ func (in *HealthService) getWorkloadRequestsHealth(namespace, workload, rateInte
 	for _, sample := range outbound {
 		rqHealth.AggregateOutbound(sample)
 	}
-	w, err := in.businessLayer.Workload.GetWorkload(namespace, workload, "", false)
+	w, err := in.businessLayer.Workload.GetWorkload(ctx, namespace, workload, "", false)
 	if err != nil {
 		return rqHealth, err
 	}
@@ -332,4 +345,113 @@ func (in *HealthService) getWorkloadRequestsHealth(namespace, workload, rateInte
 	}
 	rqHealth.CombineReporters()
 	return rqHealth, err
+}
+
+type healthServiceWithTracing struct {
+	HealthService
+}
+
+func (in *healthServiceWithTracing) GetServiceHealth(ctx context.Context, namespace, service, rateInterval string, queryTime time.Time) (models.ServiceHealth, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetServiceHealth",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("service", service),
+				attribute.String("rateInterval", rateInterval),
+				attribute.Stringer("queryTime", queryTime),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.HealthService.GetServiceHealth(ctx, namespace, service, rateInterval, queryTime)
+}
+
+func (in *healthServiceWithTracing) GetAppHealth(ctx context.Context, namespace, app, rateInterval string, queryTime time.Time) (models.AppHealth, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetAppHealth",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("app", app),
+				attribute.String("rateInterval", rateInterval),
+				attribute.Stringer("queryTime", queryTime),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.HealthService.GetAppHealth(ctx, namespace, app, rateInterval, queryTime)
+}
+
+func (in *healthServiceWithTracing) GetWorkloadHealth(ctx context.Context, namespace, workload, workloadType, rateInterval string, queryTime time.Time) (models.WorkloadHealth, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetWorkloadHealth",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("workload", workload),
+				attribute.String("workloadType", workloadType),
+				attribute.String("rateInterval", rateInterval),
+				attribute.Stringer("queryTime", queryTime),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.HealthService.GetWorkloadHealth(ctx, namespace, workload, workloadType, rateInterval, queryTime)
+}
+
+func (in *healthServiceWithTracing) GetNamespaceServiceHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceServiceHealth, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetNamespaceServiceHealth",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("rateInterval", rateInterval),
+				attribute.Stringer("queryTime", queryTime),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.HealthService.GetNamespaceServiceHealth(ctx, namespace, rateInterval, queryTime)
+}
+func (in *healthServiceWithTracing) GetNamespaceWorkloadHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceWorkloadHealth, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetNamespaceWorkloadHealth",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("rateInterval", rateInterval),
+				attribute.Stringer("queryTime", queryTime),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.HealthService.GetNamespaceWorkloadHealth(ctx, namespace, rateInterval, queryTime)
+}
+
+func (in *healthServiceWithTracing) GetNamespaceAppHealth(ctx context.Context, namespace, rateInterval string, queryTime time.Time) (models.NamespaceAppHealth, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetNamespaceAppHealth",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("rateInterval", rateInterval),
+				attribute.Stringer("queryTime", queryTime),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.HealthService.GetNamespaceAppHealth(ctx, namespace, rateInterval, queryTime)
 }

--- a/business/istio_config.go
+++ b/business/istio_config.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -406,7 +407,9 @@ func (in *IstioConfigService) GetIstioConfigList(criteria IstioConfigCriteria) (
 func (in *IstioConfigService) GetIstioConfigDetails(ctx context.Context, namespace, objectType, object string) (models.IstioConfigDetails, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		ctx, span = otel.Tracer(observability.TracerName).Start(ctx, "GetIstioConfigDetails")
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetIstioConfigDetails",
+			trace.WithAttributes(attribute.String("package", "business")),
+		)
 		defer span.End()
 	}
 	var err error
@@ -691,7 +694,12 @@ func (in *IstioConfigService) CreateIstioConfigDetail(namespace, resourceType st
 func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, namespaces []string) models.IstioConfigPermissions {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		ctx, span = otel.Tracer(observability.TracerName).Start(ctx, "GetIstioConfigPermissions")
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetIstioConfigPermissions",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.StringSlice("namespaces", namespaces),
+			),
+		)
 		defer span.End()
 	}
 	istioConfigPermissions := make(models.IstioConfigPermissions, len(namespaces))
@@ -760,7 +768,12 @@ func (in *IstioConfigService) GetIstioConfigPermissions(ctx context.Context, nam
 func getPermissions(ctx context.Context, k8s kubernetes.ClientInterface, namespace, objectType string) (bool, bool, bool) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		ctx, span = otel.Tracer(observability.TracerName).Start(ctx, "getPermissions")
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "getPermissions",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+			),
+		)
 		defer span.End()
 	}
 	var canCreate, canPatch, canDelete bool
@@ -775,7 +788,14 @@ func getPermissions(ctx context.Context, k8s kubernetes.ClientInterface, namespa
 func getPermissionsApi(ctx context.Context, k8s kubernetes.ClientInterface, namespace, api, resourceType string) (bool, bool, bool) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		ctx, span = otel.Tracer(observability.TracerName).Start(ctx, "getPermissionsApi")
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "getPermissionsApi",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("api", api),
+				attribute.String("resourceType", resourceType),
+			),
+		)
 		defer span.End()
 	}
 	var canCreate, canPatch, canDelete bool

--- a/business/istio_config_test.go
+++ b/business/istio_config_test.go
@@ -106,7 +106,7 @@ func TestGetIstioConfigList(t *testing.T) {
 
 	configService := mockGetIstioConfigList()
 
-	istioconfigList, err := configService.GetIstioConfigList(criteria)
+	istioconfigList, err := configService.GetIstioConfigList(context.TODO(), criteria)
 
 	assert.Equal(0, len(istioconfigList.Gateways))
 	assert.Equal(0, len(istioconfigList.VirtualServices))
@@ -116,7 +116,7 @@ func TestGetIstioConfigList(t *testing.T) {
 
 	criteria.IncludeGateways = true
 
-	istioconfigList, err = configService.GetIstioConfigList(criteria)
+	istioconfigList, err = configService.GetIstioConfigList(context.TODO(), criteria)
 
 	assert.Equal(2, len(istioconfigList.Gateways))
 	assert.Equal(0, len(istioconfigList.VirtualServices))
@@ -126,7 +126,7 @@ func TestGetIstioConfigList(t *testing.T) {
 
 	criteria.IncludeVirtualServices = true
 
-	istioconfigList, err = configService.GetIstioConfigList(criteria)
+	istioconfigList, err = configService.GetIstioConfigList(context.TODO(), criteria)
 
 	assert.Equal(2, len(istioconfigList.Gateways))
 	assert.Equal(2, len(istioconfigList.VirtualServices))
@@ -136,7 +136,7 @@ func TestGetIstioConfigList(t *testing.T) {
 
 	criteria.IncludeDestinationRules = true
 
-	istioconfigList, err = configService.GetIstioConfigList(criteria)
+	istioconfigList, err = configService.GetIstioConfigList(context.TODO(), criteria)
 
 	assert.Equal(2, len(istioconfigList.Gateways))
 	assert.Equal(2, len(istioconfigList.VirtualServices))
@@ -146,7 +146,7 @@ func TestGetIstioConfigList(t *testing.T) {
 
 	criteria.IncludeServiceEntries = true
 
-	istioconfigList, err = configService.GetIstioConfigList(criteria)
+	istioconfigList, err = configService.GetIstioConfigList(context.TODO(), criteria)
 
 	assert.Equal(2, len(istioconfigList.Gateways))
 	assert.Equal(2, len(istioconfigList.VirtualServices))
@@ -190,7 +190,7 @@ func TestGetIstioConfigDetails(t *testing.T) {
 	assert.Error(err)
 }
 
-func mockGetIstioConfigList() IstioConfigService {
+func mockGetIstioConfigList() istioConfigService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.On("IsOpenShift").Return(true)
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
@@ -209,7 +209,7 @@ func mockGetIstioConfigList() IstioConfigService {
 		fakeIstioObjects = append(fakeIstioObjects, s.DeepCopyObject())
 	}
 	k8s.MockIstio(fakeIstioObjects...)
-	return IstioConfigService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
+	return istioConfigService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 
 func fakeGetGateways() []networking_v1alpha3.Gateway {
@@ -370,7 +370,7 @@ func fakeGetSelfSubjectAccessReview() []*auth_v1.SelfSubjectAccessReview {
 	return []*auth_v1.SelfSubjectAccessReview{&create, &update, &delete}
 }
 
-func mockGetIstioConfigDetails() IstioConfigService {
+func mockGetIstioConfigDetails() istioConfigService {
 	k8s := new(kubetest.K8SClientMock)
 	fakeIstioObjects := []runtime.Object{}
 	fakeIstioObjects = append(fakeIstioObjects, &fakeGetGateways()[0])
@@ -383,7 +383,7 @@ func mockGetIstioConfigDetails() IstioConfigService {
 	k8s.On("GetProject", mock.AnythingOfType("string")).Return(&osproject_v1.Project{}, nil)
 	k8s.On("GetSelfSubjectAccessReview", mock.Anything, "test", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(fakeGetSelfSubjectAccessReview(), nil)
 
-	return IstioConfigService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
+	return istioConfigService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 
 func TestIsValidHost(t *testing.T) {
@@ -457,10 +457,10 @@ func TestDeleteIstioConfigDetails(t *testing.T) {
 	assert.Nil(err)
 }
 
-func mockDeleteIstioConfigDetails() IstioConfigService {
+func mockDeleteIstioConfigDetails() istioConfigService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.MockIstio(data.CreateEmptyVirtualService("reviews-to-delete", "test", []string{"reviews"}))
-	return IstioConfigService{k8s: k8s}
+	return istioConfigService{k8s: k8s}
 }
 
 func TestUpdateIstioConfigDetails(t *testing.T) {
@@ -474,17 +474,17 @@ func TestUpdateIstioConfigDetails(t *testing.T) {
 	assert.Nil(err)
 }
 
-func mockUpdateIstioConfigDetails() IstioConfigService {
+func mockUpdateIstioConfigDetails() istioConfigService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.MockIstio(data.CreateEmptyVirtualService("reviews-to-update", "test", []string{"reviews"}))
-	return IstioConfigService{k8s: k8s}
+	return istioConfigService{k8s: k8s}
 }
 
 // mockCreateIstioConfigDetails to verify the behavior of API calls is the same for create and update
-func mockCreateIstioConfigDetails() IstioConfigService {
+func mockCreateIstioConfigDetails() istioConfigService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.MockIstio()
-	return IstioConfigService{k8s: k8s}
+	return istioConfigService{k8s: k8s}
 }
 
 func TestCreateIstioConfigDetails(t *testing.T) {

--- a/business/istio_status_test.go
+++ b/business/istio_status_test.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -192,7 +193,7 @@ func TestGrafanaWorking(t *testing.T) {
 	defer httpServ.Close()
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 
 	// Requests to AddOns have to be 1
@@ -217,7 +218,7 @@ func TestGrafanaDisabled(t *testing.T) {
 	config.Set(conf)
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 
 	// Only two Istio components are missing
@@ -255,7 +256,7 @@ func TestGrafanaNotWorking(t *testing.T) {
 	config.Set(conf)
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 
 	// Grafana and two Istio comps missing
@@ -278,7 +279,7 @@ func TestFailingTracingService(t *testing.T) {
 	defer httpServ.Close()
 
 	iss := NewWithBackends(k8s, nil, mockFailingJaeger).IstioStatus
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 
 	// Requests to AddOns have to be 1
@@ -299,7 +300,7 @@ func TestOverriddenUrls(t *testing.T) {
 	defer httpServ.Close()
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 
 	// Requests to AddOns have to be 1
@@ -324,7 +325,7 @@ func TestCustomDashboardsMainPrometheus(t *testing.T) {
 	config.Set(conf)
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 
 	// Requests to AddOns have to be 1
@@ -344,7 +345,7 @@ func TestNoIstioComponentFoundError(t *testing.T) {
 	defer httpServ.Close()
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
-	_, error := iss.GetStatus()
+	_, error := iss.GetStatus(context.TODO())
 	assert.Error(error)
 }
 
@@ -362,7 +363,7 @@ func TestDefaults(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, err := iss.GetStatus()
+	icsl, err := iss.GetStatus(context.TODO())
 	assert.NoError(err)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, true)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
@@ -403,7 +404,7 @@ func TestNonDefaults(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, false)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
@@ -447,7 +448,7 @@ func TestIstiodNotReady(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, false)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
@@ -494,7 +495,7 @@ func TestIstiodUnreachable(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, false)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
@@ -542,7 +543,7 @@ func TestCustomizedAppLabel(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", NotFound, false)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
@@ -587,7 +588,7 @@ func TestDaemonSetComponentHealthy(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)
 
@@ -633,7 +634,7 @@ func TestDaemonSetComponentUnhealthy(t *testing.T) {
 
 	iss := NewWithBackends(k8s, nil, mockJaeger).IstioStatus
 
-	icsl, error := iss.GetStatus()
+	icsl, error := iss.GetStatus(context.TODO())
 	assert.NoError(error)
 	assertComponent(assert, icsl, "istio-ingressgateway", Unhealthy, false)
 	assertComponent(assert, icsl, "istio-egressgateway", Unhealthy, false)

--- a/business/istio_validations.go
+++ b/business/istio_validations.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	core_v1 "k8s.io/api/core/v1"
@@ -35,7 +36,13 @@ type ObjectChecker interface {
 func (in *IstioValidationsService) GetValidations(ctx context.Context, namespace, service string) (models.IstioValidations, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		ctx, span = otel.Tracer(observability.TracerName).Start(ctx, "GetValidations")
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetValidations",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("service", service),
+			),
+		)
 		defer span.End()
 	}
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or

--- a/business/istio_validations_test.go
+++ b/business/istio_validations_test.go
@@ -44,7 +44,7 @@ func TestGetIstioObjectValidations(t *testing.T) {
 
 	vs := mockCombinedValidationService(fakeCombinedIstioConfigList(), []string{"details", "product", "customer"}, fakePods())
 
-	validations, _ := vs.GetIstioObjectValidations("test", "virtualservices", "product-vs")
+	validations, _ := vs.GetIstioObjectValidations(context.TODO(), "test", "virtualservices", "product-vs")
 
 	assert.NotEmpty(validations)
 }
@@ -55,7 +55,7 @@ func TestGatewayValidation(t *testing.T) {
 	config.Set(conf)
 
 	v := mockMultiNamespaceGatewaysValidationService()
-	validations, _ := v.GetIstioObjectValidations("test", "gateways", "second")
+	validations, _ := v.GetIstioObjectValidations(context.TODO(), "test", "gateways", "second")
 	assert.NotEmpty(validations)
 }
 
@@ -148,7 +148,7 @@ func mockMultiNamespaceGatewaysValidationService() IstioValidationsService {
 	k8s.On("GetDeployments", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(FakeDepSyncedWithRS(), nil)
 	k8s.On("GetMeshPolicies", mock.AnythingOfType("string")).Return(fakeMeshPolicies(), nil)
 
-	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
+	return &istioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 
 func mockCombinedValidationService(istioConfigList *models.IstioConfigList, services []string, podList *core_v1.PodList) IstioValidationsService {
@@ -196,15 +196,15 @@ func mockCombinedValidationService(istioConfigList *models.IstioConfigList, serv
 
 	mockWorkLoadService(k8s)
 
-	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
+	return &istioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 
-func mockEmptyValidationService() IstioValidationsService {
+func mockEmptyValidationService() istioValidationsService {
 	k8s := new(kubetest.K8SClientMock)
 	k8s.MockIstio()
 	k8s.On("IsOpenShift").Return(false)
 	k8s.On("IsMaistraApi").Return(false)
-	return IstioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
+	return istioValidationsService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 }
 
 func fakeCombinedIstioConfigList() *models.IstioConfigList {

--- a/business/layer.go
+++ b/business/layer.go
@@ -127,26 +127,26 @@ func SetWithBackends(cf kubernetes.ClientFactory, prom prometheus.ClientInterfac
 // NewWithBackends creates the business layer using the passed k8s and prom clients
 func NewWithBackends(k8s kubernetes.ClientInterface, prom prometheus.ClientInterface, jaegerClient JaegerLoader) *Layer {
 	temporaryLayer := &Layer{}
-	temporaryLayer.App = AppService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.Health = HealthService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.IstioConfig = IstioConfigService{k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.IstioStatus = IstioStatusService{k8s: k8s, businessLayer: temporaryLayer}
+	temporaryLayer.App = &appServiceWithTracing{AppService: &appService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}}
+	temporaryLayer.Health = &healthServiceWithTracing{HealthService: &healthService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}}
+	temporaryLayer.IstioConfig = &istioConfigServiceWithTracing{IstioConfigService: &istioConfigService{k8s: k8s, businessLayer: temporaryLayer}}
+	temporaryLayer.IstioStatus = &istioStatusServiceWithTracing{IstioStatusService: &istioStatusService{k8s: k8s, businessLayer: temporaryLayer}}
 	temporaryLayer.IstioCerts = IstioCertsService{k8s: k8s, businessLayer: temporaryLayer}
 	temporaryLayer.Iter8 = Iter8Service{k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.Jaeger = JaegerService{loader: jaegerClient, businessLayer: temporaryLayer}
+	temporaryLayer.Jaeger = &jaegerServiceWithTracing{JaegerService: &jaegerService{loader: jaegerClient, businessLayer: temporaryLayer}}
 	temporaryLayer.k8s = k8s
 	temporaryLayer.Mesh = NewMeshService(k8s, temporaryLayer, nil)
-	temporaryLayer.Namespace = NewNamespaceService(k8s)
+	temporaryLayer.Namespace = &namespaceServiceWithTracing{NamespaceService: NewNamespaceService(k8s)}
 	temporaryLayer.OpenshiftOAuth = OpenshiftOAuthService{k8s: k8s}
 	temporaryLayer.ProxyStatus = ProxyStatusService{k8s: k8s, businessLayer: temporaryLayer}
 	// Out of order because it relies on ProxyStatus
 	temporaryLayer.ProxyLogging = ProxyLoggingService{k8s: k8s, proxyStatus: &temporaryLayer.ProxyStatus}
 	temporaryLayer.RegistryStatus = RegistryStatusService{k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.Svc = SvcService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.TLS = TLSService{k8s: k8s, businessLayer: temporaryLayer}
+	temporaryLayer.Svc = &svcServiceWithTracing{SvcService: &svcService{prom: prom, k8s: k8s, businessLayer: temporaryLayer}}
+	temporaryLayer.TLS = &tlsServiceWithTracing{TLSService: &tlsService{k8s: k8s, businessLayer: temporaryLayer}}
 	temporaryLayer.TokenReview = NewTokenReview(k8s)
-	temporaryLayer.Validations = IstioValidationsService{k8s: k8s, businessLayer: temporaryLayer}
-	temporaryLayer.Workload = WorkloadService{k8s: k8s, prom: prom, businessLayer: temporaryLayer}
+	temporaryLayer.Validations = &istioValidationsServiceWithTracing{IstioValidationsService: &istioValidationsService{k8s: k8s, businessLayer: temporaryLayer}}
+	temporaryLayer.Workload = &workloadService{k8s: k8s, prom: prom, businessLayer: temporaryLayer}
 
 	return temporaryLayer
 }

--- a/business/mesh.go
+++ b/business/mesh.go
@@ -239,8 +239,14 @@ func (in *MeshService) ResolveKialiControlPlaneCluster(r *http.Request) (*Cluste
 		return nil, err
 	}
 
+	var ctx context.Context
+	if r != nil {
+		ctx = r.Context()
+	} else {
+		ctx = context.Background()
+	}
 	// Discover ourselves
-	kialiInstances := findKialiInNamespace(os.Getenv("ACTIVE_NAMESPACE"), myClusterName, in.layer)
+	kialiInstances := findKialiInNamespace(ctx, os.Getenv("ACTIVE_NAMESPACE"), myClusterName, in.layer)
 	if len(kialiInstances) > 0 && r != nil {
 		for i := range kialiInstances {
 			// If URL is already populated (because of an annotation), trust that because it's user configuration.
@@ -279,8 +285,8 @@ func convertKialiServiceToInstance(svc *core_v1.Service) KialiInstance {
 // The clientSet argument should be an already initialized REST client to the API server of the
 // cluster. The namespace argument specifies the namespace where a Kiali instance will be looked for.
 // The clusterName argument is for logging purposes only.
-func findKialiInNamespace(namespace string, clusterName string, layer *Layer) (instances []KialiInstance) {
-	kialiNs, getNsErr := layer.Namespace.GetNamespace(context.TODO(), namespace)
+func findKialiInNamespace(ctx context.Context, namespace string, clusterName string, layer *Layer) (instances []KialiInstance) {
+	kialiNs, getNsErr := layer.Namespace.GetNamespace(ctx, namespace)
 	if getNsErr != nil && !errors.IsNotFound(getNsErr) {
 		log.Warningf("Discovery for Kiali instances in cluster [%s] failed: %s", clusterName, getNsErr.Error())
 		return

--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -6,6 +6,7 @@ import (
 
 	osproject_v1 "github.com/openshift/api/project/v1"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -179,7 +180,12 @@ func (in *NamespaceService) isExcludedNamespace(namespace string) bool {
 func (in *NamespaceService) GetNamespace(ctx context.Context, namespace string) (*models.Namespace, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		_, span = otel.Tracer(observability.TracerName).Start(ctx, "GetNamespace")
+		_, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetNamespace",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+			),
+		)
 		defer span.End()
 	}
 	var err error

--- a/business/services.go
+++ b/business/services.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
@@ -17,15 +20,25 @@ import (
 	"github.com/kiali/kiali/kubernetes"
 	"github.com/kiali/kiali/log"
 	"github.com/kiali/kiali/models"
+	"github.com/kiali/kiali/observability"
 	"github.com/kiali/kiali/prometheus"
 )
 
 // SvcService deals with fetching istio/kubernetes services related content and convert to kiali model
-type SvcService struct {
+type SvcService interface {
+	GetServiceList(ctx context.Context, criteria ServiceCriteria) (*models.ServiceList, error)
+	GetServiceDetails(ctx context.Context, namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error)
+	UpdateService(ctx context.Context, namespace, service string, interval string, queryTime time.Time, jsonPatch string) (*models.ServiceDetails, error)
+	GetService(ctx context.Context, namespace, service string) (models.Service, error)
+	GetServiceAppName(ctx context.Context, namespace, service string) (string, error)
+}
+
+type svcService struct {
 	prom          prometheus.ClientInterface
 	k8s           kubernetes.ClientInterface
 	businessLayer *Layer
 }
+
 
 type ServiceCriteria struct {
 	Namespace              string
@@ -35,7 +48,7 @@ type ServiceCriteria struct {
 }
 
 // GetServiceList returns a list of all services for a given criteria
-func (in *SvcService) GetServiceList(criteria ServiceCriteria) (*models.ServiceList, error) {
+func (in *svcService) GetServiceList(ctx context.Context, criteria ServiceCriteria) (*models.ServiceList, error) {
 	var svcs []core_v1.Service
 	var rSvcs []*kubernetes.RegistryService
 	var pods []core_v1.Pod
@@ -44,7 +57,7 @@ func (in *SvcService) GetServiceList(criteria ServiceCriteria) (*models.ServiceL
 	var err error
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err = in.businessLayer.Namespace.GetNamespace(context.TODO(), criteria.Namespace); err != nil {
+	if _, err = in.businessLayer.Namespace.GetNamespace(ctx, criteria.Namespace); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +158,7 @@ func (in *SvcService) GetServiceList(criteria ServiceCriteria) (*models.ServiceL
 		go func() {
 			defer wg.Done()
 			var err2 error
-			istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigList(criteria)
+			istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigList(ctx, criteria)
 			if err2 != nil {
 				log.Errorf("Error fetching IstioConfigList per namespace %s: %s", criteria.Namespace, err2)
 				errChan <- err2
@@ -183,7 +196,7 @@ func getDRKialiScenario(dr []networking_v1alpha3.DestinationRule) string {
 	return scenario
 }
 
-func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v1.Service, rSvcs []*kubernetes.RegistryService, pods []core_v1.Pod, deployments []apps_v1.Deployment, istioConfigList models.IstioConfigList) *models.ServiceList {
+func (in *svcService) buildServiceList(namespace models.Namespace, svcs []core_v1.Service, rSvcs []*kubernetes.RegistryService, pods []core_v1.Pod, deployments []apps_v1.Deployment, istioConfigList models.IstioConfigList) *models.ServiceList {
 	var services []models.ServiceOverview
 	validations := in.getServiceValidations(svcs, deployments, pods)
 
@@ -198,7 +211,7 @@ func (in *SvcService) buildServiceList(namespace models.Namespace, svcs []core_v
 	return &models.ServiceList{Namespace: namespace, Services: services, Validations: validations}
 }
 
-func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []core_v1.Pod, istioConfigList models.IstioConfigList) []models.ServiceOverview {
+func (in *svcService) buildKubernetesServices(svcs []core_v1.Service, pods []core_v1.Pod, istioConfigList models.IstioConfigList) []models.ServiceOverview {
 	services := make([]models.ServiceOverview, len(svcs))
 	conf := config.Get()
 
@@ -252,7 +265,7 @@ func (in *SvcService) buildKubernetesServices(svcs []core_v1.Service, pods []cor
 	return services
 }
 
-func (in *SvcService) buildRegistryServices(rSvcs []*kubernetes.RegistryService, istioConfigList models.IstioConfigList) []models.ServiceOverview {
+func (in *svcService) buildRegistryServices(rSvcs []*kubernetes.RegistryService, istioConfigList models.IstioConfigList) []models.ServiceOverview {
 	services := make([]models.ServiceOverview, len(rSvcs))
 	conf := config.Get()
 
@@ -303,14 +316,14 @@ func (in *SvcService) buildRegistryServices(rSvcs []*kubernetes.RegistryService,
 }
 
 // GetService returns a single service and associated data using the interval and queryTime
-func (in *SvcService) GetServiceDetails(namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error) {
+func (in *svcService) GetServiceDetails(ctx context.Context, namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error) {
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespace(context.TODO(), namespace); err != nil {
+	if _, err := in.businessLayer.Namespace.GetNamespace(ctx, namespace); err != nil {
 		return nil, err
 	}
 
-	svc, err := in.GetService(namespace, service)
+	svc, err := in.GetService(ctx, namespace, service)
 	if err != nil {
 		return nil, err
 	}
@@ -347,15 +360,15 @@ func (in *SvcService) GetServiceDetails(namespace, service, interval string, que
 			}
 		}()
 
-		go func() {
+		go func(ctx context.Context) {
 			defer wg.Done()
 			var err2 error
-			ws, err2 = fetchWorkloads(in.businessLayer, namespace, labelsSelector)
+			ws, err2 = fetchWorkloads(ctx, in.businessLayer, namespace, labelsSelector)
 			if err2 != nil {
 				log.Errorf("Error fetching Workloads per namespace %s and service %s: %s", namespace, service, err2)
 				errChan <- err2
 			}
-		}()
+		}(ctx)
 	}
 
 	go func() {
@@ -372,12 +385,12 @@ func (in *SvcService) GetServiceDetails(namespace, service, interval string, que
 		}
 	}()
 
-	go func() {
+	go func(ctx context.Context) {
 		defer wg.Done()
 		var err2 error
 		if IsNamespaceCached(namespace) {
 			// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-			if _, err = in.businessLayer.Namespace.GetNamespace(context.TODO(), namespace); err == nil {
+			if _, err = in.businessLayer.Namespace.GetNamespace(ctx, namespace); err == nil {
 				eps, err = kialiCache.GetEndpoints(namespace, service)
 			}
 		} else {
@@ -387,27 +400,27 @@ func (in *SvcService) GetServiceDetails(namespace, service, interval string, que
 			log.Errorf("Error fetching Endpoints namespace %s and service %s: %s", namespace, service, err2)
 			errChan <- err2
 		}
-	}()
+	}(ctx)
 
-	go func() {
+	go func(ctx context.Context) {
 		defer wg.Done()
 		var err2 error
-		hth, err2 = in.businessLayer.Health.GetServiceHealth(namespace, service, interval, queryTime)
+		hth, err2 = in.businessLayer.Health.GetServiceHealth(ctx, namespace, service, interval, queryTime)
 		if err2 != nil {
 			errChan <- err2
 		}
-	}()
+	}(ctx)
 
-	go func() {
+	go func(ctx context.Context) {
 		defer wg.Done()
 		var err2 error
-		nsmtls, err2 = in.businessLayer.TLS.NamespaceWidemTLSStatus(context.TODO(), namespace)
+		nsmtls, err2 = in.businessLayer.TLS.NamespaceWidemTLSStatus(ctx, namespace)
 		if err2 != nil {
 			errChan <- err2
 		}
-	}()
+	}(ctx)
 
-	go func() {
+	go func(ctx context.Context) {
 		defer wg.Done()
 		var err2 error
 		criteria := IstioConfigCriteria{
@@ -419,12 +432,12 @@ func (in *SvcService) GetServiceDetails(namespace, service, interval string, que
 			IncludeServiceEntries:  true,
 			IncludeVirtualServices: true,
 		}
-		istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigList(criteria)
+		istioConfigList, err2 = in.businessLayer.IstioConfig.GetIstioConfigList(ctx, criteria)
 		if err2 != nil {
 			log.Errorf("Error fetching IstioConfigList per namespace %s: %s", criteria.Namespace, err2)
 			errChan <- err2
 		}
-	}()
+	}(ctx)
 
 	var vsCreate, vsUpdate, vsDelete bool
 	go func() {
@@ -476,7 +489,7 @@ func (in *SvcService) GetServiceDetails(namespace, service, interval string, que
 	return &s, nil
 }
 
-func (in *SvcService) UpdateService(namespace, service string, interval string, queryTime time.Time, jsonPatch string) (*models.ServiceDetails, error) {
+func (in *svcService) UpdateService(ctx context.Context, namespace, service string, interval string, queryTime time.Time, jsonPatch string) (*models.ServiceDetails, error) {
 	// Identify controller and apply patch to workload
 	err := updateService(in.businessLayer, namespace, service, jsonPatch)
 	if err != nil {
@@ -489,16 +502,16 @@ func (in *SvcService) UpdateService(namespace, service string, interval string, 
 	}
 
 	// After the update we fetch the whole workload
-	return in.GetServiceDetails(namespace, service, interval, queryTime)
+	return in.GetServiceDetails(ctx, namespace, service, interval, queryTime)
 }
 
-func (in *SvcService) GetService(namespace, service string) (models.Service, error) {
+func (in *svcService) GetService(ctx context.Context, namespace, service string) (models.Service, error) {
 	var err error
 	var kSvc *core_v1.Service
 	svc := models.Service{}
 	if IsNamespaceCached(namespace) {
 		// Cache uses Kiali ServiceAccount, check if user can access to the namespace
-		if _, err = in.businessLayer.Namespace.GetNamespace(context.TODO(), namespace); err == nil {
+		if _, err = in.businessLayer.Namespace.GetNamespace(ctx, namespace); err == nil {
 			kSvc, err = kialiCache.GetService(namespace, service)
 		}
 	} else {
@@ -530,7 +543,7 @@ func (in *SvcService) GetService(namespace, service string) (models.Service, err
 	return svc, err
 }
 
-func (in *SvcService) getServiceValidations(services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) models.IstioValidations {
+func (in *svcService) getServiceValidations(services []core_v1.Service, deployments []apps_v1.Deployment, pods []core_v1.Pod) models.IstioValidations {
 	validations := checkers.ServiceChecker{
 		Services:    services,
 		Deployments: deployments,
@@ -542,14 +555,14 @@ func (in *SvcService) getServiceValidations(services []core_v1.Service, deployme
 
 // GetServiceAppName returns the "Application" name (app label) that relates to a service
 // This label is taken from the service selector, which means it is assumed that pods are selected using that label
-func (in *SvcService) GetServiceAppName(namespace, service string) (string, error) {
+func (in *svcService) GetServiceAppName(ctx context.Context, namespace, service string) (string, error) {
 	// Check if user has access to the namespace (RBAC) in cache scenarios and/or
 	// if namespace is accessible from Kiali (Deployment.AccessibleNamespaces)
-	if _, err := in.businessLayer.Namespace.GetNamespace(context.TODO(), namespace); err != nil {
+	if _, err := in.businessLayer.Namespace.GetNamespace(ctx, namespace); err != nil {
 		return "", err
 	}
 
-	svc, err := in.GetService(namespace, service)
+	svc, err := in.GetService(ctx, namespace, service)
 	if err != nil {
 		return "", fmt.Errorf("Service [namespace: %s] [name: %s] doesn't exist.", namespace, service)
 	}
@@ -567,4 +580,89 @@ func updateService(layer *Layer, namespace string, service string, jsonPatch str
 	}
 
 	return layer.k8s.UpdateService(namespace, service, jsonPatch)
+}
+
+type svcServiceWithTracing struct {
+	SvcService
+}
+
+func (in *svcServiceWithTracing) GetServiceList(ctx context.Context, criteria ServiceCriteria) (*models.ServiceList, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetServiceList",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.SvcService.GetServiceList(ctx, criteria)
+}
+
+func (in *svcServiceWithTracing) GetServiceDetails(ctx context.Context, namespace, service, interval string, queryTime time.Time) (*models.ServiceDetails, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetServiceDetails",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("service", service),
+				attribute.String("interval", interval),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.SvcService.GetServiceDetails(ctx, namespace, service, interval, queryTime)
+}
+
+func (in *svcServiceWithTracing) UpdateService(ctx context.Context, namespace, service string, interval string, queryTime time.Time, jsonPatch string) (*models.ServiceDetails, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "UpdateService",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("service", service),
+				attribute.String("interval", interval),
+				attribute.String("jsonPatch", jsonPatch),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.SvcService.UpdateService(ctx, namespace, service, interval, queryTime, jsonPatch)
+}
+
+func (in *svcServiceWithTracing) GetService(ctx context.Context, namespace, service string) (models.Service, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetService",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("service", service),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.SvcService.GetService(ctx, namespace, service)
+}
+
+func (in *svcServiceWithTracing) GetServiceAppName(ctx context.Context, namespace, service string) (string, error) {
+	if config.Get().Server.Observability.Tracing.Enabled {
+		var span trace.Span
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "GetServiceAppName",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+				attribute.String("service", service),
+			),
+		)
+		defer span.End()
+	}
+
+	return in.SvcService.GetServiceAppName(ctx, namespace, service)
 }

--- a/business/services_test.go
+++ b/business/services_test.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -25,10 +26,10 @@ func TestServiceListParsing(t *testing.T) {
 	k8s.On("GetNamespace", mock.AnythingOfType("string")).Return(&core_v1.Namespace{}, nil)
 	conf := config.NewConfig()
 	config.Set(conf)
-	svc := SvcService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
+	svc := svcService{k8s: k8s, businessLayer: NewWithBackends(k8s, nil, nil)}
 
 	criteria := ServiceCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	serviceList, _ := svc.GetServiceList(criteria)
+	serviceList, _ := svc.GetServiceList(context.TODO(), criteria)
 
 	assert.Equal("Namespace", serviceList.Namespace.Name)
 	assert.Len(serviceList.Services, 2)
@@ -44,7 +45,7 @@ func TestParseRegistryServices(t *testing.T) {
 
 	conf := config.NewConfig()
 	config.Set(conf)
-	svc := SvcService{k8s: nil, businessLayer: nil}
+	svc := svcService{k8s: nil, businessLayer: nil}
 
 	servicesz := "../tests/data/registry/services-registryz.json"
 	bServicesz, err := ioutil.ReadFile(servicesz)

--- a/business/tls.go
+++ b/business/tls.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	networking_v1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	security_v1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -65,7 +66,12 @@ func (in *TLSService) getMeshPeerAuthentications() ([]security_v1beta1.PeerAuthe
 func (in *TLSService) getAllDestinationRules(ctx context.Context, namespaces []string) ([]networking_v1alpha3.DestinationRule, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		_, span = otel.Tracer(observability.TracerName).Start(ctx, "getAllDestinationRules")
+		_, span = otel.Tracer(observability.TracerName()).Start(ctx, "getAllDestinationRules",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.StringSlice("namespaces", namespaces),
+			),
+		)
 		defer span.End()
 	}
 	drChan := make(chan []networking_v1alpha3.DestinationRule, len(namespaces))
@@ -112,7 +118,12 @@ func (in *TLSService) getAllDestinationRules(ctx context.Context, namespaces []s
 func (in TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace string) (models.MTLSStatus, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		ctx, span = otel.Tracer(observability.TracerName).Start(ctx, "NamespaceWidemTLSStatus")
+		ctx, span = otel.Tracer(observability.TracerName()).Start(ctx, "NamespaceWidemTLSStatus",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+			),
+		)
 		defer span.End()
 	}
 	pas, err := in.getPeerAuthentications(ctx, namespace)
@@ -146,7 +157,12 @@ func (in TLSService) NamespaceWidemTLSStatus(ctx context.Context, namespace stri
 func (in TLSService) getPeerAuthentications(ctx context.Context, namespace string) ([]security_v1beta1.PeerAuthentication, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		_, span = otel.Tracer(observability.TracerName).Start(ctx, "getPeerAuthentications")
+		_, span = otel.Tracer(observability.TracerName()).Start(ctx, "getPeerAuthentications",
+			trace.WithAttributes(
+				attribute.String("package", "business"),
+				attribute.String("namespace", namespace),
+			),
+		)
 		defer span.End()
 	}
 	if config.IsRootNamespace(namespace) {
@@ -163,7 +179,9 @@ func (in TLSService) getPeerAuthentications(ctx context.Context, namespace strin
 func (in TLSService) getNamespaces(ctx context.Context) ([]string, error) {
 	if config.Get().Server.Observability.Tracing.Enabled {
 		var span trace.Span
-		_, span = otel.Tracer(observability.TracerName).Start(ctx, "getNamespaces")
+		_, span = otel.Tracer(observability.TracerName()).Start(ctx, "getNamespaces",
+			trace.WithAttributes(attribute.String("package", "business")),
+		)
 		defer span.End()
 	}
 	nss, nssErr := in.businessLayer.Namespace.GetNamespaces()

--- a/business/tls_perf_test.go
+++ b/business/tls_perf_test.go
@@ -84,10 +84,11 @@ func testPerfScenario(exStatus string, nss []core_v1.Namespace, drs []networking
 	for _, ns := range nss {
 		k8s.On("GetNamespace", ns.Name).Return(&ns, nil)
 	}
-	config.Set(config.NewConfig())
+	conf = config.NewConfig()
+	conf.Deployment.AccessibleNamespaces = []string{"**"}
+	config.Set(conf)
 
-	tlsService := TLSService{k8s: k8s, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8s, nil, nil)}
-	tlsService.businessLayer.Namespace.isAccessibleNamespaces["**"] = true
+	tlsService := tlsService{k8s: k8s, enabledAutoMtls: &autoMtls, businessLayer: NewWithBackends(k8s, nil, nil)}
 	for _, ns := range nss {
 		status, err := (tlsService).NamespaceWidemTLSStatus(context.TODO(), ns.Name)
 		assert.NoError(err)

--- a/business/workloads_test.go
+++ b/business/workloads_test.go
@@ -1,6 +1,7 @@
 package business
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ import (
 
 func setupWorkloadService(k8s *kubetest.K8SClientMock) WorkloadService {
 	prom := new(prometheustest.PromClientMock)
-	return WorkloadService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
+	return &workloadService{k8s: k8s, prom: prom, businessLayer: NewWithBackends(k8s, prom, nil)}
 }
 
 func TestGetWorkloadListFromDeployments(t *testing.T) {
@@ -54,7 +55,7 @@ func TestGetWorkloadListFromDeployments(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -98,7 +99,7 @@ func TestGetWorkloadListFromReplicaSets(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -139,7 +140,7 @@ func TestGetWorkloadListFromReplicationControllers(t *testing.T) {
 
 	excludedWorkloads = map[string]bool{}
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -182,7 +183,7 @@ func TestGetWorkloadListFromDeploymentConfigs(t *testing.T) {
 
 	excludedWorkloads = map[string]bool{}
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -225,7 +226,7 @@ func TestGetWorkloadListFromStatefulSets(t *testing.T) {
 
 	excludedWorkloads = map[string]bool{}
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -268,7 +269,7 @@ func TestGetWorkloadListFromDaemonSets(t *testing.T) {
 
 	excludedWorkloads = map[string]bool{}
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -310,7 +311,7 @@ func TestGetWorkloadListFromDepRCPod(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -344,7 +345,7 @@ func TestGetWorkloadListFromPod(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -378,7 +379,7 @@ func TestGetWorkloadListFromPods(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
 	assert.Equal("Namespace", workloadList.Namespace.Name)
@@ -419,7 +420,7 @@ func TestGetWorkloadFromDeployment(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
-	workload, _ := svc.GetWorkload("Namespace", "details-v1", "", false)
+	workload, _ := svc.GetWorkload(context.TODO(), "Namespace", "details-v1", "", false)
 
 	assert.Equal("details-v1", workload.Name)
 	assert.Equal("Deployment", workload.Type)
@@ -456,7 +457,7 @@ func TestGetWorkloadWithInvalidWorkloadType(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
-	workload, _ := svc.GetWorkload("Namespace", "details-v1", "invalid", false)
+	workload, _ := svc.GetWorkload(context.TODO(), "Namespace", "details-v1", "invalid", false)
 
 	assert.Equal("details-v1", workload.Name)
 	assert.Equal("Deployment", workload.Type)
@@ -493,7 +494,7 @@ func TestGetWorkloadFromPods(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
-	workload, _ := svc.GetWorkload("Namespace", "custom-controller", "", false)
+	workload, _ := svc.GetWorkload(context.TODO(), "Namespace", "custom-controller", "", false)
 
 	assert.Equal("custom-controller", workload.Name)
 	assert.Equal("CustomController", workload.Type)
@@ -515,7 +516,7 @@ func TestGetPods(t *testing.T) {
 
 	svc := setupWorkloadService(k8s)
 
-	pods, _ := svc.GetPods("Namespace", "app=httpbin")
+	pods, _ := svc.GetPods(context.TODO(), "Namespace", "app=httpbin")
 
 	assert.Equal(1, len(pods))
 	assert.Equal("details-v1-3618568057-dnkjp", pods[0].Name)
@@ -718,10 +719,10 @@ func TestDuplicatedControllers(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
-	workload, _ := svc.GetWorkload("Namespace", "duplicated-v1", "", false)
+	workload, _ := svc.GetWorkload(context.TODO(), "Namespace", "duplicated-v1", "", false)
 
 	assert.Equal(workloads[0].Type, workload.Type)
 }
@@ -774,10 +775,10 @@ func TestGetWorkloadListFromGenericPodController(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
-	workload, _ := svc.GetWorkload("Namespace", owner.Name, "", false)
+	workload, _ := svc.GetWorkload(context.TODO(), "Namespace", owner.Name, "", false)
 
 	assert.Equal(len(workloads), 1)
 	assert.NotNil(workload)
@@ -837,10 +838,10 @@ func TestGetWorkloadListRSOwnedByCustom(t *testing.T) {
 	svc := setupWorkloadService(k8s)
 
 	criteria := WorkloadCriteria{Namespace: "Namespace", IncludeIstioResources: false}
-	workloadList, _ := svc.GetWorkloadList(criteria)
+	workloadList, _ := svc.GetWorkloadList(context.TODO(), criteria)
 	workloads := workloadList.Workloads
 
-	workload, _ := svc.GetWorkload("Namespace", owner.Name, "", false)
+	workload, _ := svc.GetWorkload(context.TODO(), "Namespace", owner.Name, "", false)
 
 	assert.Equal(len(workloads), 1)
 	assert.NotNil(workload)

--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kiali/kiali/business"
@@ -235,7 +236,7 @@ func getServiceList(namespace string, gi *graph.AppenderGlobalInfo) *models.Serv
 		Namespace:              namespace,
 		IncludeOnlyDefinitions: true,
 	}
-	serviceList, err := gi.Business.Svc.GetServiceList(criteria)
+	serviceList, err := gi.Business.Svc.GetServiceList(context.TODO(), criteria)
 	graph.CheckError(err)
 	serviceListMap[namespace] = serviceList
 
@@ -275,7 +276,7 @@ func getWorkloadList(namespace string, gi *graph.AppenderGlobalInfo) *models.Wor
 	}
 
 	criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false}
-	workloadList, err := gi.Business.Workload.GetWorkloadList(criteria)
+	workloadList, err := gi.Business.Workload.GetWorkloadList(context.TODO(), criteria)
 	graph.CheckError(err)
 	workloadListMap[namespace] = &workloadList
 

--- a/graph/telemetry/istio/appender/istio_details.go
+++ b/graph/telemetry/istio/appender/istio_details.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -45,7 +46,7 @@ func (a IstioAppender) AppendGraph(trafficMap graph.TrafficMap, globalInfo *grap
 
 func addBadging(trafficMap graph.TrafficMap, globalInfo *graph.AppenderGlobalInfo, namespaceInfo *graph.AppenderNamespaceInfo) {
 	// Currently no other appenders use DestinationRules or VirtualServices, so they are not cached in AppenderNamespaceInfo
-	istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
+	istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(context.TODO(), business.IstioConfigCriteria{
 		IncludeDestinationRules: true,
 		IncludeVirtualServices:  true,
 		Namespace:               namespaceInfo.Namespace,
@@ -285,7 +286,7 @@ func (a IstioAppender) getIstioComponentWorkloads(component string, globalInfo *
 	componentWorkloads := make(map[string][]models.WorkloadListItem)
 	for namespace := range a.AccessibleNamespaces {
 		criteria := business.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false}
-		wList, err := globalInfo.Business.Workload.GetWorkloadList(criteria)
+		wList, err := globalInfo.Business.Workload.GetWorkloadList(context.TODO(), criteria)
 		graph.CheckError(err)
 
 		// Find Istio component deployments
@@ -304,7 +305,7 @@ func (a IstioAppender) getIstioComponentWorkloads(component string, globalInfo *
 func (a IstioAppender) getIstioGatewayResources(globalInfo *graph.AppenderGlobalInfo) []networking_v1alpha3.Gateway {
 	retVal := []networking_v1alpha3.Gateway{}
 	for namespace := range a.AccessibleNamespaces {
-		istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
+		istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(context.TODO(), business.IstioConfigCriteria{
 			IncludeGateways: true,
 			Namespace:       namespace,
 		})

--- a/graph/telemetry/istio/appender/service_entry.go
+++ b/graph/telemetry/istio/appender/service_entry.go
@@ -1,6 +1,7 @@
 package appender
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -155,7 +156,7 @@ func (a ServiceEntryAppender) getServiceEntry(namespace, serviceName string, glo
 	serviceEntryHosts, found := getServiceEntryHosts(globalInfo)
 	if !found {
 		for ns := range a.AccessibleNamespaces {
-			istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
+			istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(context.TODO(), business.IstioConfigCriteria{
 				IncludeServiceEntries: true,
 				Namespace:             ns,
 			})

--- a/graph/telemetry/istio/appender/workload_entry.go
+++ b/graph/telemetry/istio/appender/workload_entry.go
@@ -1,6 +1,8 @@
 package appender
 
 import (
+	"context"
+
 	"github.com/kiali/kiali/business"
 	"github.com/kiali/kiali/config"
 	"github.com/kiali/kiali/graph"
@@ -49,7 +51,7 @@ func (a WorkloadEntryAppender) applyWorkloadEntries(trafficMap graph.TrafficMap,
 			continue
 		}
 
-		istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(business.IstioConfigCriteria{
+		istioCfg, err := globalInfo.Business.IstioConfig.GetIstioConfigList(context.TODO(), business.IstioConfigCriteria{
 			IncludeWorkloadEntries: true,
 			Namespace:              n.Namespace,
 		})

--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -19,7 +19,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 
 	// Fetch and build apps
-	appList, err := business.App.GetAppList(namespace, true)
+	appList, err := business.App.GetAppList(r.Context(), namespace, true)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -41,7 +41,7 @@ func AppDetails(w http.ResponseWriter, r *http.Request) {
 	app := params["app"]
 
 	// Fetch and build app
-	appDetails, err := business.App.GetApp(namespace, app)
+	appDetails, err := business.App.GetApp(r.Context(), namespace, app)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return

--- a/handlers/dashboards.go
+++ b/handlers/dashboards.go
@@ -33,7 +33,7 @@ func CustomDashboard(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	info, err := checkNamespaceAccess(layer.Namespace, namespace)
+	info, err := checkNamespaceAccess(r.Context(), layer.Namespace, namespace)
 	if err != nil {
 		RespondWithError(w, http.StatusForbidden, "Cannot access namespace data: "+err.Error())
 		return
@@ -48,7 +48,7 @@ func CustomDashboard(w http.ResponseWriter, r *http.Request) {
 
 	var wkd *models.Workload
 	if params.Workload != "" {
-		wkd, err = layer.Workload.GetWorkload(namespace, params.Workload, params.WorkloadType, false)
+		wkd, err = layer.Workload.GetWorkload(r.Context(), namespace, params.Workload, params.WorkloadType, false)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				RespondWithError(w, http.StatusNotFound, err.Error())
@@ -165,7 +165,7 @@ func ServiceDashboard(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
-	svc, err := b.Svc.GetService(namespace, service)
+	svc, err := b.Svc.GetService(r.Context(), namespace, service)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -32,7 +32,7 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Adjust rate interval
-	rateInterval, err := adjustRateInterval(business, p.Namespace, p.RateInterval, p.QueryTime)
+	rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
 	if err != nil {
 		handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 		return
@@ -40,21 +40,21 @@ func NamespaceHealth(w http.ResponseWriter, r *http.Request) {
 
 	switch p.Type {
 	case "app":
-		health, err := business.Health.GetNamespaceAppHealth(p.Namespace, rateInterval, p.QueryTime)
+		health, err := business.Health.GetNamespaceAppHealth(r.Context(), p.Namespace, rateInterval, p.QueryTime)
 		if err != nil {
 			handleErrorResponse(w, err, "Error while fetching app health: "+err.Error())
 			return
 		}
 		RespondWithJSON(w, http.StatusOK, health)
 	case "service":
-		health, err := business.Health.GetNamespaceServiceHealth(p.Namespace, rateInterval, p.QueryTime)
+		health, err := business.Health.GetNamespaceServiceHealth(r.Context(), p.Namespace, rateInterval, p.QueryTime)
 		if err != nil {
 			handleErrorResponse(w, err, "Error while fetching service health: "+err.Error())
 			return
 		}
 		RespondWithJSON(w, http.StatusOK, health)
 	case "workload":
-		health, err := business.Health.GetNamespaceWorkloadHealth(p.Namespace, rateInterval, p.QueryTime)
+		health, err := business.Health.GetNamespaceWorkloadHealth(r.Context(), p.Namespace, rateInterval, p.QueryTime)
 		if err != nil {
 			handleErrorResponse(w, err, "Error while fetching workload health: "+err.Error())
 			return
@@ -73,13 +73,13 @@ func AppHealth(w http.ResponseWriter, r *http.Request) {
 
 	p := appHealthParams{}
 	p.extract(r)
-	rateInterval, err := adjustRateInterval(business, p.Namespace, p.RateInterval, p.QueryTime)
+	rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
 	if err != nil {
 		handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 		return
 	}
 
-	health, err := business.Health.GetAppHealth(p.Namespace, p.App, rateInterval, p.QueryTime)
+	health, err := business.Health.GetAppHealth(r.Context(), p.Namespace, p.App, rateInterval, p.QueryTime)
 	handleHealthResponse(w, health, err)
 }
 
@@ -93,14 +93,14 @@ func WorkloadHealth(w http.ResponseWriter, r *http.Request) {
 
 	p := workloadHealthParams{}
 	p.extract(r)
-	rateInterval, err := adjustRateInterval(business, p.Namespace, p.RateInterval, p.QueryTime)
+	rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
 	if err != nil {
 		handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 		return
 	}
 	p.RateInterval = rateInterval
 
-	health, err := business.Health.GetWorkloadHealth(p.Namespace, p.Workload, p.WorkloadType, rateInterval, p.QueryTime)
+	health, err := business.Health.GetWorkloadHealth(r.Context(), p.Namespace, p.Workload, p.WorkloadType, rateInterval, p.QueryTime)
 	handleHealthResponse(w, health, err)
 }
 
@@ -114,13 +114,13 @@ func ServiceHealth(w http.ResponseWriter, r *http.Request) {
 
 	p := serviceHealthParams{}
 	p.extract(r)
-	rateInterval, err := adjustRateInterval(business, p.Namespace, p.RateInterval, p.QueryTime)
+	rateInterval, err := adjustRateInterval(r.Context(), business, p.Namespace, p.RateInterval, p.QueryTime)
 	if err != nil {
 		handleErrorResponse(w, err, "Adjust rate interval error: "+err.Error())
 		return
 	}
 
-	health, err := business.Health.GetServiceHealth(p.Namespace, p.Service, rateInterval, p.QueryTime)
+	health, err := business.Health.GetServiceHealth(r.Context(), p.Namespace, p.Service, rateInterval, p.QueryTime)
 	handleHealthResponse(w, health, err)
 }
 
@@ -244,8 +244,8 @@ func (p *workloadHealthParams) extract(r *http.Request) {
 	p.WorkloadType = query.Get("type")
 }
 
-func adjustRateInterval(business *business.Layer, namespace, rateInterval string, queryTime time.Time) (string, error) {
-	namespaceInfo, err := business.Namespace.GetNamespace(context.TODO(), namespace)
+func adjustRateInterval(ctx context.Context, business *business.Layer, namespace, rateInterval string, queryTime time.Time) (string, error) {
+	namespaceInfo, err := business.Namespace.GetNamespace(ctx, namespace)
 	if err != nil {
 		return "", err
 	}

--- a/handlers/istio_config.go
+++ b/handlers/istio_config.go
@@ -72,7 +72,7 @@ func IstioConfigList(w http.ResponseWriter, r *http.Request) {
 		}(namespace, &istioConfigValidations, &err)
 	}
 
-	istioConfig, err := business.IstioConfig.GetIstioConfigList(criteria)
+	istioConfig, err := business.IstioConfig.GetIstioConfigList(r.Context(), criteria)
 	if includeValidations {
 		// Add validation results to the IstioConfigList once they're available (previously done in the UI layer)
 		wg.Wait()
@@ -118,7 +118,7 @@ func IstioConfigDetails(w http.ResponseWriter, r *http.Request) {
 		wg.Add(1)
 		go func(istioConfigValidations *models.IstioValidations, err *error) {
 			defer wg.Done()
-			istioConfigValidationResults, errValidations := business.Validations.GetIstioObjectValidations(namespace, objectType, object)
+			istioConfigValidationResults, errValidations := business.Validations.GetIstioObjectValidations(r.Context(), namespace, objectType, object)
 			if errValidations != nil && *err == nil {
 				*err = errValidations
 			} else {

--- a/handlers/istio_status.go
+++ b/handlers/istio_status.go
@@ -13,7 +13,7 @@ func IstioStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	istioStatus, err := business.IstioStatus.GetStatus()
+	istioStatus, err := business.IstioStatus.GetStatus(r.Context())
 	if err != nil {
 		handleErrorResponse(w, err)
 		return

--- a/handlers/iter8.go
+++ b/handlers/iter8.go
@@ -71,7 +71,7 @@ func Iter8ExperimentGet(w http.ResponseWriter, r *http.Request) {
 	}
 	if experiment.ExperimentItem.Kind == "Deployment" {
 		criteria := business2.WorkloadCriteria{Namespace: namespace, IncludeIstioResources: false}
-		workloadList, err := business.Workload.GetWorkloadList(criteria)
+		workloadList, err := business.Workload.GetWorkloadList(r.Context(), criteria)
 		if err != nil {
 			handleErrorResponse(w, err)
 			return
@@ -90,7 +90,7 @@ func Iter8ExperimentGet(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		serviceList, err := business.Svc.GetServiceList(criteria)
+		serviceList, err := business.Svc.GetServiceList(r.Context(), criteria)
 		if err != nil {
 			handleErrorResponse(w, err)
 			return

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -73,7 +73,7 @@ func ServiceTraces(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	traces, err := business.Jaeger.GetServiceTraces(namespace, service, q)
+	traces, err := business.Jaeger.GetServiceTraces(r.Context(), namespace, service, q)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
@@ -95,7 +95,7 @@ func WorkloadTraces(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	traces, err := business.Jaeger.GetWorkloadTraces(namespace, workload, q)
+	traces, err := business.Jaeger.GetWorkloadTraces(r.Context(), namespace, workload, q)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
@@ -191,7 +191,7 @@ func ServiceSpans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	spans, err := business.Jaeger.GetServiceSpans(namespace, service, q)
+	spans, err := business.Jaeger.GetServiceSpans(r.Context(), namespace, service, q)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return
@@ -217,7 +217,7 @@ func WorkloadSpans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	spans, err := business.Jaeger.GetWorkloadSpans(namespace, workload, q)
+	spans, err := business.Jaeger.GetWorkloadSpans(r.Context(), namespace, workload, q)
 	if err != nil {
 		RespondWithError(w, http.StatusServiceUnavailable, err.Error())
 		return

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -69,7 +69,7 @@ func NamespaceUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	jsonPatch := string(body)
 
-	ns, err := business.Namespace.UpdateNamespace(namespace, jsonPatch)
+	ns, err := business.Namespace.UpdateNamespace(r.Context(), namespace, jsonPatch)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -25,7 +25,7 @@ func ServiceList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch and build services
-	serviceList, err := business.Svc.GetServiceList(criteria)
+	serviceList, err := business.Svc.GetServiceList(r.Context(), criteria)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -59,7 +59,7 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 	service := params["service"]
 	queryTime := util.Clock.Now()
-	rateInterval, err = adjustRateInterval(business, namespace, rateInterval, queryTime)
+	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -77,7 +77,7 @@ func ServiceDetails(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
-	serviceDetails, err := business.Svc.GetServiceDetails(namespace, service, rateInterval, queryTime)
+	serviceDetails, err := business.Svc.GetServiceDetails(r.Context(), namespace, service, rateInterval, queryTime)
 	if includeValidations && err == nil {
 		wg.Wait()
 		serviceDetails.Validations = istioConfigValidations
@@ -116,7 +116,7 @@ func ServiceUpdate(w http.ResponseWriter, r *http.Request) {
 	namespace := params["namespace"]
 	service := params["service"]
 	queryTime := util.Clock.Now()
-	rateInterval, err = adjustRateInterval(business, namespace, rateInterval, queryTime)
+	rateInterval, err = adjustRateInterval(r.Context(), business, namespace, rateInterval, queryTime)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, "Adjust rate interval error: "+err.Error())
 		return
@@ -139,7 +139,7 @@ func ServiceUpdate(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
-	serviceDetails, err := business.Svc.UpdateService(namespace, service, rateInterval, queryTime, jsonPatch)
+	serviceDetails, err := business.Svc.UpdateService(r.Context(), namespace, service, rateInterval, queryTime, jsonPatch)
 
 	if includeValidations && err == nil {
 		wg.Wait()

--- a/handlers/tls.go
+++ b/handlers/tls.go
@@ -55,7 +55,7 @@ func MeshTls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get mtls status given the whole namespaces
-	globalmTLSStatus, err := business.TLS.MeshWidemTLSStatus(nsNames)
+	globalmTLSStatus, err := business.TLS.MeshWidemTLSStatus(r.Context(), nsNames)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, http.StatusInternalServerError, err.Error())

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -17,8 +17,8 @@ type promClientSupplier func() (*prometheus.Client, error)
 
 var defaultPromClientSupplier = prometheus.NewClient
 
-func checkNamespaceAccess(nsServ business.NamespaceService, namespace string) (*models.Namespace, error) {
-	if nsInfo, err := nsServ.GetNamespace(context.TODO(), namespace); err != nil {
+func checkNamespaceAccess(ctx context.Context, nsServ business.NamespaceService, namespace string) (*models.Namespace, error) {
+	if nsInfo, err := nsServ.GetNamespace(ctx, namespace); err != nil {
 		return nil, err
 	} else {
 		return nsInfo, nil
@@ -57,7 +57,7 @@ func createMetricsServiceForNamespaces(w http.ResponseWriter, r *http.Request, p
 
 	nsInfos := make(map[string]nsInfoError)
 	for _, ns := range namespaces {
-		info, err := checkNamespaceAccess(layer.Namespace, ns)
+		info, err := checkNamespaceAccess(r.Context(), layer.Namespace, ns)
 		nsInfos[ns] = nsInfoError{info: info, err: err}
 	}
 	metrics := business.NewMetricsService(prom)

--- a/handlers/workloads.go
+++ b/handlers/workloads.go
@@ -24,7 +24,7 @@ func WorkloadList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch and build workloads
-	workloadList, err := business.Workload.GetWorkloadList(criteria)
+	workloadList, err := business.Workload.GetWorkloadList(r.Context(), criteria)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -49,7 +49,7 @@ func WorkloadDetails(w http.ResponseWriter, r *http.Request) {
 	workloadType := query.Get("type")
 
 	// Fetch and build workload
-	workloadDetails, err := business.Workload.GetWorkload(namespace, workload, workloadType, true)
+	workloadDetails, err := business.Workload.GetWorkload(r.Context(), namespace, workload, workloadType, true)
 	if err != nil {
 		handleErrorResponse(w, err)
 		return
@@ -79,7 +79,7 @@ func WorkloadUpdate(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusBadRequest, "Update request with bad update patch: "+err.Error())
 	}
 	jsonPatch := string(body)
-	workloadDetails, err := business.Workload.UpdateWorkload(namespace, workload, workloadType, true, jsonPatch)
+	workloadDetails, err := business.Workload.UpdateWorkload(r.Context(), namespace, workload, workloadType, true, jsonPatch)
 
 	if err != nil {
 		handleErrorResponse(w, err)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -490,6 +490,7 @@ func (in *K8SClient) GetSelfSubjectAccessReview(ctx context.Context, namespace, 
 		)
 		defer span.End()
 	}
+
 	calls := len(verbs)
 	ch := make(chan *auth_v1.SelfSubjectAccessReview, calls)
 	errChan := make(chan error)

--- a/observability/tracing.go
+++ b/observability/tracing.go
@@ -36,7 +36,7 @@ func InitTracer(jaegerURL string) *sdktrace.TracerProvider {
 	}
 
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.5))), // Sample half of traces. 
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.5))), // Sample half of traces.
 		sdktrace.WithBatcher(exporter),
 		// Record information about this application in an Resource.
 		sdktrace.WithResource(resource.NewWithAttributes(

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,7 @@ func NewServer() *Server {
 	router := routing.NewRouter()
 	var tracingProvider *sdktrace.TracerProvider
 	if conf.Server.Observability.Tracing.Enabled {
-		log.Debugf("Tracing Enabled. Initializing tracer with collector url: %s", conf.Server.Observability.Tracing.CollectorURL)
+		log.Infof("Tracing Enabled. Initializing tracer with collector url: %s", conf.Server.Observability.Tracing.CollectorURL)
 		tracingProvider = observability.InitTracer(conf.Server.Observability.Tracing.CollectorURL)
 	}
 


### PR DESCRIPTION
Converts business structs to interfaces and adds a tracing implementation for most of them. This moves the tracing logic out of each service.

In the future, it's possible for the tracing code to be generated by reading an interface that has been tagged with someone like `kiali-gen:tracing`.