### PR TITLE
Fix issue related to int test fail

### DIFF
--- a/graph/telemetry/istio/appender/appender.go
+++ b/graph/telemetry/istio/appender/appender.go
@@ -250,7 +250,7 @@ func ParseAppenders(o graph.TelemetryOptions) (appenders []Appender, finalizers 
 		Namespaces:           o.Namespaces,
 	})
 
-	if _, ok := requestedFinalizers[IstioAppenderName]; ok {
+	if _, ok := requestedFinalizers[IstioAppenderName]; ok || o.Appenders.All {
 		finalizers = append(finalizers, &IstioAppender{})
 	}
 


### PR DESCRIPTION
This is a real test fail. The integration test does not send the "app" param, which means run all appenders. But the new finalizer istio appender check did not carry that conditional.